### PR TITLE
Fix header images in posts are jumping to another position

### DIFF
--- a/_layouts/post.liquid
+++ b/_layouts/post.liquid
@@ -52,7 +52,6 @@ layout: default
   header#main {
       background-size: cover;
       background-repeat: no-repeat;
-      background-position: center;
   }
 
   {% if page.color %}


### PR DESCRIPTION
Header-Bilder in den Blogeinträgen (`layout: post`) haben die Position des Bildes geändert, sobald man angefangen hat, die frisch geladene Seite zu scrollen. 
Mit dem Commit passiert das nicht mehr und ist dann auch konsistent mit den Seiten vom Typ `layout: pages`