### PR TITLE
34 kalender elemente auf mobile geräte neu anordnen

### DIFF
--- a/pages/01_events.md
+++ b/pages/01_events.md
@@ -22,7 +22,14 @@ icon: "far fa-calendar"
           initialView: 'dayGridMonth',
           height: "auto",
           locale: 'de',
-          events: '/calendar-data'
+          events: '/calendar-data',
+          weekNumbers: true,
+          headerToolbar:
+          {
+            left: 'today',
+            center: 'title',
+            right: 'prev,next'
+          }
         });
         calendar.render();
       });

--- a/pages/01_events.md
+++ b/pages/01_events.md
@@ -19,7 +19,10 @@ icon: "far fa-calendar"
       document.addEventListener('DOMContentLoaded', function() {
         var calendarEl = document.getElementById('calendar');
         var calendar = new FullCalendar.Calendar(calendarEl, {
-          initialView: 'dayGridMonth', height: "auto", locale: 'de', events: '/calendar-data'
+          initialView: 'dayGridMonth',
+          height: "auto",
+          locale: 'de',
+          events: '/calendar-data'
         });
         calendar.render();
       });


### PR DESCRIPTION
Habe das Problem umgegangen, indem ich den "Heute"- Button nach links gepackt habe und den Monatstitel in die Mitte.

Desweiteren werden nun die Wochennummern angezeigt.